### PR TITLE
Add install() rule for headers

### DIFF
--- a/play_motion/CMakeLists.txt
+++ b/play_motion/CMakeLists.txt
@@ -38,6 +38,11 @@ install (PROGRAMS scripts/is_already_there.py
 install(PROGRAMS scripts/move_joint
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
+install(DIRECTORY include/
+   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+   FILES_MATCHING PATTERN "*.h"
+)
+
 # tests
 #######
 if(CATKIN_ENABLE_TESTING)


### PR DESCRIPTION
Now that we have a library, we should also install the headers.
