### PR TITLE
Add new optional config parameter.

### DIFF
--- a/play_motion/config/sample.yaml
+++ b/play_motion/config/sample.yaml
@@ -11,9 +11,12 @@ play_motion:
     exclude_from_planning_joints: # motion planning will not be used for these
       -fake_joint_2
 
-    joint_tolerance: 0.01
-    skip_planning_approach_vel: 0.5
-    skip_planning_approach_min_dur: 0.5
+    joint_tolerance: 0.001              # rad or m
+
+    # The following two parameters are likely to be removed soon in favor of a
+    # better solution:
+    skip_planning_approach_vel: 0.5     # rad/s or m/s
+    skip_planning_approach_min_dur: 0.0 # s
 
   # actual motions that robot can execute. Normally loaded in a separate file,
   # to decouple play_motion behavior config (above) from robot-specific motions

--- a/play_motion/config/sample.yaml
+++ b/play_motion/config/sample.yaml
@@ -13,6 +13,7 @@ play_motion:
 
     joint_tolerance: 0.01
     skip_planning_approach_vel: 0.5
+    skip_planning_approach_min_dur: 0.5
 
   # actual motions that robot can execute. Normally loaded in a separate file,
   # to decouple play_motion behavior config (above) from robot-specific motions

--- a/play_motion/include/play_motion/approach_planner.h
+++ b/play_motion/include/play_motion/approach_planner.h
@@ -105,6 +105,7 @@ namespace play_motion
     std::vector<std::string> no_plan_joints_;
     double joint_tol_; ///< Absolute tolerance used to determine if two joint positions are approximately equal.
     double skip_planning_vel_; ///< Maximum average velocity that any joint can have in a non-planned approach.
+    double skip_planning_min_dur_; ///< Minimum duration that a non-planned approach can have
     CallbackQueuePtr cb_queue_;
     AsyncSpinnerPtr spinner_;
     bool planning_disabled_;


### PR DESCRIPTION
Add new parameter to configure the minimum approach time to use when
skip_planning = true.

If we time-parameterize trajectories using MoveIt's built-in methods, we'd
be able to get rid of this additional parameter, but in the meantime, it
addresses an important issue.
