### PR TITLE
Convenience functions

### DIFF
--- a/play_motion/include/play_motion/play_motion_helpers.h
+++ b/play_motion/include/play_motion/play_motion_helpers.h
@@ -112,8 +112,8 @@ namespace play_motion
    *        only the joints in targetJoint will be checked
    * \param tolerance tolerance per joint in radians
    */
-  bool isAlreadyThere(const JointNames &targetJoints, const TrajPoint &targetPoint,
-                      const JointNames &sourceJoints, const TrajPoint &sourcePoint,
+  bool isAlreadyThere(const JointNames &target_joints, const TrajPoint &target_point,
+                      const JointNames &source_joints, const TrajPoint &source_point,
                       double tolerance = 0.15);
 
   /**
@@ -167,8 +167,8 @@ namespace play_motion
    * \throws ros::Exception if the motion does not exist or is malformed.
    */
   void getMotion(const ros::NodeHandle &nh, const std::string &motion_id,
-                 MotionInfo &motionInfo);
-  void getMotion(const std::string &motion_id, MotionInfo &motionInfo);
+                 MotionInfo &motion_info);
+  void getMotion(const std::string &motion_id, MotionInfo &motion_info);
 }
 
 #endif

--- a/play_motion/include/play_motion/play_motion_helpers.h
+++ b/play_motion/include/play_motion/play_motion_helpers.h
@@ -35,6 +35,7 @@
 /** \author Adolfo Rodriguez Tsouroukdissian. */
 /** \author Paul Mathieu.                     */
 /** \author Victor Lopez.                     */
+/** \author Bence Magyar.                     */
 
 #ifndef PLAYMOTIONHELPERS_H
 #define PLAYMOTIONHELPERS_H
@@ -62,20 +63,22 @@ namespace play_motion
 
   /**
    * \param nh Nodehandle with the namespace containing the motions
-   *           (ie ros::NodeHandle nh("play_motion"))
+   *           (When omitted, defaults to ros::NodeHandle nh("play_motion"))
    * \throws xh::XmlrpcHelperException if motion_id cannot be found
    */
   void getMotionJoints(const ros::NodeHandle &nh, const std::string& motion_id,
                        JointNames& motion_joints);
+  void getMotionJoints(const std::string& motion_id, JointNames& motion_joints);
 
 
   /**
    * \param nh Nodehandle with the namespace containing the motions
-   *           (ie ros::NodeHandle nh("play_motion"))
+   *           (When omitted, defaults to ros::NodeHandle nh("play_motion"))
    * \throws xh::XmlrpcHelperException if motion_id cannot be found
    */
   void getMotionPoints(const ros::NodeHandle &nh, const std::string& motion_id,
                        Trajectory& motion_points);
+  void getMotionPoints(const std::string& motion_id, Trajectory& motion_points);
 
 
   /**
@@ -88,18 +91,20 @@ namespace play_motion
   /**
    * \brief getMotions obtain all motion names
    * \param nh Nodehandle with the namespace containing the motions
-   *           (ie ros::NodeHandle nh("play_motion"))
+   *           (When omitted, defaults to ros::NodeHandle nh("play_motion"))
    * \throws xh::XmlrpcHelperException if no motions available
    */
   void getMotionIds(const ros::NodeHandle &nh, MotionNames& motion_ids);
+  void getMotionIds(MotionNames& motion_ids);
 
   /**
    * \param nh Nodehandle with the namespace containing the motions
-   *           (ie ros::NodeHandle nh("play_motion"))
+   *           (When omitted, defaults to ros::NodeHandle nh("play_motion"))
    * \param motion_id Motion identifier
    * \return True if the motion exists, false otherwise
    */
   bool motionExists(const ros::NodeHandle &nh, const std::string &motion_id);
+  bool motionExists(const std::string &motion_id);
 
   /**
    * \brief isAlreadyThere checks if the source trajPoint matches the target
@@ -156,13 +161,14 @@ namespace play_motion
   /**
    * \brief Parse a motion specified in the ROS parameter server into a data structure.
    * \param[in] nh Nodehandle with the namespace containing the motions
-   *           (ie ros::NodeHandle nh("play_motion"))
+   *           (When omitted, defaults to ros::NodeHandle nh("play_motion"))
    * \param[in] motion_id Motion identifier
    * \param[out] motionInfo Data structure containing parsed motion
    * \throws ros::Exception if the motion does not exist or is malformed.
    */
   void getMotion(const ros::NodeHandle &nh, const std::string &motion_id,
                  MotionInfo &motionInfo);
+  void getMotion(const std::string &motion_id, MotionInfo &motionInfo);
 }
 
 #endif

--- a/play_motion/src/play_motion_helpers.cpp
+++ b/play_motion/src/play_motion_helpers.cpp
@@ -226,35 +226,34 @@ namespace play_motion
     return motionExists(pm_nh, motion_id);
   }
 
-
-  bool isAlreadyThere(const JointNames &targetJoints, const TrajPoint &targetPoint,
-                      const JointNames &sourceJoints, const TrajPoint &sourcePoint,
+  bool isAlreadyThere(const JointNames &target_joints, const TrajPoint &target_point,
+                      const JointNames &source_joints, const TrajPoint &source_point,
                       double tolerance)
   {
-    if (targetJoints.size() != targetPoint.positions.size())
+    if (target_joints.size() != target_point.positions.size())
       throw ros::Exception("targetJoint and targetPoint positions sizes do not match");
 
-    if (sourceJoints.size() != sourcePoint.positions.size())
+    if (source_joints.size() != source_point.positions.size())
       throw ros::Exception("sourceJoint and sourcePoint positions sizes do not match");
 
-    for (int tIndex = 0; tIndex < targetJoints.size(); ++tIndex)
+    for (int tIndex = 0; tIndex < target_joints.size(); ++tIndex)
     {
-      JointNames::const_iterator it = std::find(sourceJoints.begin(), sourceJoints.end(),
-                                                targetJoints[tIndex]);
+      JointNames::const_iterator it = std::find(source_joints.begin(), source_joints.end(),
+                                                target_joints[tIndex]);
       /// If a joint used in the target is not used in the available in the
       /// source can't guarantee that the points are equivalent
-      if (it == sourceJoints.end())
+      if (it == source_joints.end())
         return false;
 
-      int sIndex = it - sourceJoints.begin();
-      if (std::fabs(targetPoint.positions[tIndex] - sourcePoint.positions[sIndex]) > tolerance)
+      int sIndex = it - source_joints.begin();
+      if (std::fabs(target_point.positions[tIndex] - source_point.positions[sIndex]) > tolerance)
         return false;
     }
     return true;
   }
 
   void getMotion(const ros::NodeHandle &nh, const std::string &motion_id,
-                 MotionInfo &motionInfo)
+                 MotionInfo &motion_info)
   {
     if (!motionExists(nh, motion_id))
     {
@@ -262,30 +261,30 @@ namespace play_motion
                                "(namespace " + getMotionsNodeHandle(nh).getNamespace() + ").";
       throw ros::Exception(what);
     }
-    motionInfo.id = motion_id;
+    motion_info.id = motion_id;
     xh::Struct param;
     xh::fetchParam(getMotionsNodeHandle(nh), motion_id, param);
 
-    extractTrajectory(param["points"], motionInfo.traj);
-    extractJoints(param["joints"], motionInfo.joints);
+    extractTrajectory(param["points"], motion_info.traj);
+    extractJoints(param["joints"], motion_info.joints);
     if (param.hasMember("meta"))
     {
-      xh::getStructMember(param["meta"], "description", motionInfo.description);
-      xh::getStructMember(param["meta"], "name", motionInfo.name);
-      xh::getStructMember(param["meta"], "usage", motionInfo.usage);
+      xh::getStructMember(param["meta"], "description", motion_info.description);
+      xh::getStructMember(param["meta"], "name", motion_info.name);
+      xh::getStructMember(param["meta"], "usage", motion_info.usage);
     }
     else
     {
-      motionInfo.description = "";
-      motionInfo.name = "";
-      motionInfo.usage = "";
+      motion_info.description = "";
+      motion_info.name = "";
+      motion_info.usage = "";
     }
   }
 
-  void getMotion(const std::string &motion_id, MotionInfo &motionInfo)
+  void getMotion(const std::string &motion_id, MotionInfo &motion_info)
   {
     ros::NodeHandle pm_nh("play_motion");
-    play_motion::getMotion(pm_nh, motion_id, motionInfo);
+    play_motion::getMotion(pm_nh, motion_id, motion_info);
   }
 
 }

--- a/play_motion/src/play_motion_helpers.cpp
+++ b/play_motion/src/play_motion_helpers.cpp
@@ -34,6 +34,7 @@
 
 /** \author Paul Mathieu. */
 /** \author Victor Lopez. */
+/** \author Bence Magyar. */
 #include "play_motion/play_motion_helpers.h"
 #include <cassert>
 
@@ -96,12 +97,24 @@ namespace play_motion
     motion_joints = info.joints;
   }
 
+  void getMotionJoints(const std::string& motion_id, JointNames& motion_joints)
+  {
+    ros::NodeHandle pm_nh("play_motion");
+    getMotionJoints(pm_nh, motion_id, motion_joints);
+  }
+
   void getMotionPoints(const ros::NodeHandle &nh, const std::string& motion_id,
                        Trajectory& motion_points)
   {
     MotionInfo info;
     getMotion(nh, motion_id, info);
     motion_points = info.traj;
+  }
+
+  void getMotionPoints(const std::string& motion_id, Trajectory& motion_points)
+  {
+    ros::NodeHandle pm_nh("play_motion");
+    getMotionPoints(pm_nh, motion_id, motion_points);
   }
 
   void getMotionIds(const ros::NodeHandle &nh, MotionNames& motion_ids)
@@ -113,6 +126,12 @@ namespace play_motion
     {
       motion_ids.push_back(it->first);
     }
+  }
+
+  void getMotionIds(MotionNames& motion_ids)
+  {
+    ros::NodeHandle pm_nh("play_motion");
+    getMotionIds(pm_nh, motion_ids);
   }
 
   void populateVelocities(const TrajPoint& point_prev,
@@ -182,6 +201,12 @@ namespace play_motion
     return traj.back().time_from_start;
   }
 
+  ros::Duration getMotionDuration(const std::string &motion_id)
+  {
+      ros::NodeHandle pm_nh("play_motion");
+      return getMotionDuration(pm_nh, motion_id);
+  }
+
   bool motionExists(const ros::NodeHandle &nh, const std::string &motion_id)
   {
     try
@@ -194,6 +219,13 @@ namespace play_motion
       return false;
     }
   }
+
+  bool motionExists(const std::string &motion_id)
+  {
+    ros::NodeHandle pm_nh("play_motion");
+    return motionExists(pm_nh, motion_id);
+  }
+
 
   bool isAlreadyThere(const JointNames &targetJoints, const TrajPoint &targetPoint,
                       const JointNames &sourceJoints, const TrajPoint &sourcePoint,
@@ -250,5 +282,10 @@ namespace play_motion
     }
   }
 
+  void getMotion(const std::string &motion_id, MotionInfo &motionInfo)
+  {
+    ros::NodeHandle pm_nh("play_motion");
+    play_motion::getMotion(pm_nh, motion_id, motionInfo);
+  }
 
 }


### PR DESCRIPTION
Added alternative functions to each helper which requires a NodeHandle. Now without this argument the overridden functions create one with the default namespace (play_motion) and call the former functions. 

Also refactored a few argument names that were using camelCase while the majority uses underscores in this file.
