### PR TITLE
Add missing configuration for depender projects

### DIFF
--- a/play_motion/CMakeLists.txt
+++ b/play_motion/CMakeLists.txt
@@ -7,7 +7,9 @@ find_package(Boost REQUIRED COMPONENTS thread)
 catkin_python_setup()
 
 catkin_package(INCLUDE_DIRS include
-               LIBRARIES play_motion_helpers)
+               LIBRARIES play_motion_helpers
+               CATKIN_DEPENDS roscpp  play_motion_msgs actionlib moveit_ros_planning_interface sensor_msgs)
+
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 

--- a/play_motion/package.xml
+++ b/play_motion/package.xml
@@ -26,6 +26,7 @@
   <run_depend>play_motion_msgs</run_depend>
   <run_depend>moveit_ros_planning_interface</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
 
   <!-- test build depends -->
   <build_depend>controller_manager</build_depend>


### PR DESCRIPTION
Dependencies of play_motion where not exported as CATKIN_DEPENDS on catkin_package invocation.
Also added a missing run_depend.
