### PR TITLE
Drop SYSTEM option to avoid compilation errors with modern compilers

### DIFF
--- a/play_motion/CMakeLists.txt
+++ b/play_motion/CMakeLists.txt
@@ -17,7 +17,7 @@ catkin_package(INCLUDE_DIRS include
 
 
 include_directories(include)
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS})
 
 add_library(play_motion_helpers src/play_motion_helpers.cpp)
 


### PR DESCRIPTION
This commit fix compilation errors with gcc-8 in a Debian Buster box.

In file included from /usr/include/c++/8/ext/string_conversions.h:41,
                 from /usr/include/c++/8/bits/basic_string.h:6400,
                 from /usr/include/c++/8/string:52,
                 from /home/users/leopold.palomo/ros/catkin_ws_pal/src/play_motion/play_motion/include/play_motion/play_motion_helpers.h:43,
                 from /home/users/leopold.palomo/ros/catkin_ws_pal/src/play_motion/play_motion/src/play_motion_helpers.cpp:38:
/usr/include/c++/8/cstdlib:75:15: fatal error: stdlib.h: El fitxer o directori no existeix
 #include_next <stdlib.h>
               ^~~~~~~~~~
compilation terminated.
[ 33%] Building CXX object CMakeFiles/pm_rrbot.dir/test/rrbot.cpp.o
make[2]: *** [CMakeFiles/play_motion_helpers.dir/build.make:63: CMakeFiles/play_motion_helpers.dir/src/play_motion_helpers.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1849: CMakeFiles/play_motion_helpers.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
In file included from /usr/include/c++/8/ext/string_conversions.h:41,
                 from /usr/include/c++/8/bits/basic_string.h:6400,
                 from /usr/include/c++/8/string:52,
                 from /usr/include/ros/platform.h:38,
                 from /usr/include/ros/time.h:53,
                 from /usr/include/ros/ros.h:38,
                 from /home/users/leopold.palomo/ros/catkin_ws_pal/src/play_motion/play_motion/test/rrbot.cpp:31:
/usr/include/c++/8/cstdlib:75:15: fatal error: stdlib.h: El fitxer o directori no existeix
 #include_next <stdlib.h>
               ^~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/pm_rrbot.dir/build.make:63: CMakeFiles/pm_rrbot.dir/test/rrbot.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:106: CMakeFiles/pm_rrbot.dir/all] Error 2
[ 38%] Building CXX object CMakeFiles/run_motion.dir/src/run_motion_node.cpp.o
In file included from /usr/include/c++/8/ext/string_conversions.h:41,
                 from /usr/include/c++/8/bits/basic_string.h:6400,
                 from /usr/include/c++/8/string:52,
                 from /home/users/leopold.palomo/ros/catkin_ws_pal/src/play_motion/play_motion/src/run_motion_node.cpp:40:
/usr/include/c++/8/cstdlib:75:15: fatal error: stdlib.h: El fitxer o directori no existeix
 #include_next <stdlib.h>
               ^~~~~~~~~~
