### PR TITLE
remove -std= flags for building in jammy

### DIFF
--- a/play_motion/CMakeLists.txt
+++ b/play_motion/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(play_motion)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-
 find_package(catkin REQUIRED COMPONENTS actionlib control_msgs controller_manager_msgs
   play_motion_msgs moveit_ros_planning_interface roscpp sensor_msgs
   diagnostic_msgs diagnostic_updater)


### PR DESCRIPTION
I want to release this repository for ros-o + Ubuntu Jammy. This PR fixes 

```
 In file included from /usr/include/log4cxx/log4cxx.h:45,
                   from /usr/include/log4cxx/logstring.h:28,
                   from /usr/include/log4cxx/level.h:22,
                   from /opt/ros/one/include/ros/console.h:46,
                   from /opt/ros/one/include/ros/ros.h:40,
                   from /<<BUILDDIR>>ros-one-play-motion-0.4.15/src/play_motion_helpers.cpp:41:
  /usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
     10 |     typedef std::shared_mutex shared_mutex;
        |                  ^~~~~~~~~~~~
  /usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
     10 |     typedef std::shared_mutex shared_mutex;
        |             ^~~
  /usr/include/log4cxx/boost-std-configuration.h:12:30: error: ‘shared_lock’ in namespace ‘std’ does not name a template type
     12 |     using shared_lock = std::shared_lock<T>;
        |                              ^~~~~~~~~~~
  /usr/include/log4cxx/boost-std-configuration.h:12:25: note: ‘std::shared_lock’ is only available from C++14 onwards
     12 |     using shared_lock = std::shared_lock<T>;
        |                         ^~~
  make[4]: *** [CMakeFiles/play_motion_helpers.dir/build.make:79: CMakeFiles/play_motion_helpers.dir/src/play_motion_helpers.cpp.o] Error 1
  make[4]: Leaving directory '/<<BUILDDIR>>ros-one-play-motion-0.4.15/.obj-x86_64-linux-gnu'
  make[3]: *** [CMakeFiles/Makefile2:3060: CMakeFiles/play_motion_helpers.dir/all] Error 2
  make[3]: *** Waiting for unfinished jobs....
  In file included from /usr/include/log4cxx/log4cxx.h:45,
                   from /usr/include/log4cxx/logstring.h:28,
                   from /usr/include/log4cxx/level.h:22,
                   from /opt/ros/one/include/ros/console.h:46,
                   from /opt/ros/one/include/ros/ros.h:40,
                   from /<<BUILDDIR>>ros-one-play-motion-0.4.15/src/run_motion_node.cpp:46:
  /usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
     10 |     typedef std::shared_mutex shared_mutex;
        |                  ^~~~~~~~~~~~
  /usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
     10 |     typedef std::shared_mutex shared_mutex;
        |             ^~~
  /usr/include/log4cxx/boost-std-configuration.h:12:30: error: ‘shared_lock’ in namespace ‘std’ does not name a template type
     12 |     using shared_lock = std::shared_lock<T>;
        |                              ^~~~~~~~~~~
  /usr/include/log4cxx/boost-std-configuration.h:12:25: note: ‘std::shared_lock’ is only available from C++14 onwards
     12 |     using shared_lock = std::shared_lock<T>;
        |                         ^~~
  make[4]: *** [CMakeFiles/run_motion.dir/build.make:79: CMakeFiles/run_motion.dir/src/run_motion_node.cpp.o] Error 1
  make[4]: Leaving directory '/<<BUILDDIR>>ros-one-play-motion-0.4.15/.obj-x86_64-linux-gnu'
  make[3]: *** [CMakeFiles/Makefile2:3220: CMakeFiles/run_motion.dir/all] Error 2
  make[3]: Leaving directory '/<<BUILDDIR>>ros-one-play-motion-0.4.15/.obj-x86_64-linux-gnu'
  make[2]: *** [Makefile:139: all] Error 2

```